### PR TITLE
[#66] typeorm의 seed 라이브러리의 문제점

### DIFF
--- a/data-source.ts
+++ b/data-source.ts
@@ -34,6 +34,14 @@ const options: DataSourceOptions & SeederOptions = {
     logging: true,
     seeds: [`src/database/seeds/**/*{.js,.ts}`],
     factories: [`src/database/factories/**/*{.js,.ts}`],
+    extra: {
+        connectionLimit: 30,
+        queueLimit: 0,
+        waitForConnections: true,
+    },
+    // 커넥션 풀 사이즈 설정
+    poolSize: 30,
+    connectTimeout: 120000,
 };
 
 export const dataSource = new DataSource(options);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       container_name: mysql_prod
       volumes:
           - ./mysql-data:/var/lib/mysql
+          - ./mysql/my.cnf:/etc/mysql/conf.d/my.cnf
       ports:
           - "${MYSQL_OUTBOUND_PORT}:${MYSQL_INBOUND_PORT}"
       environment:

--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -1,0 +1,11 @@
+[mysqld]
+innodb_stats_auto_recalc = 1
+innodb_stats_persistent = 1
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci
+
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set = utf8mb4

--- a/src/database/factories/article.factory.ts
+++ b/src/database/factories/article.factory.ts
@@ -2,18 +2,45 @@ import { setSeederFactory } from "typeorm-extension";
 
 import { ArticleEntity } from "@APP/entities/article.entity";
 
+import { MEMBER_ID_RANGE } from "../utils/member-id-range.const";
+
+// export default setSeederFactory(ArticleEntity, async (faker) => {
+//     const article = new ArticleEntity();
+//     const startDate = faker.date.recent({ days: 365 });
+
+//     article.title = faker.lorem.sentence();
+//     article.content = faker.lorem.paragraph();
+//     article.startTime = faker.date.recent({ days: 365 });
+//     article.endTime = faker.date.soon({ days: 1, refDate: article.startTime });
+//     article.articleImage = faker.image.url();
+//     article.memberId = faker.number.int({ min: 1, max: 100 });
+//     article.categoryId = faker.number.int({ min: 1, max: 16 });
+//     article.regionId = faker.number.int({ min: 1, max: 1 });
+//     article.districtId = faker.number.int({ min: 1, max: 129 });
+//     article.createdAt = startDate;
+//     article.updatedAt = startDate;
+
+//     return article;
+// });
+
 export default setSeederFactory(ArticleEntity, async (faker) => {
     const article = new ArticleEntity();
     const startDate = faker.date.recent({ days: 365 });
 
-    article.title = faker.lorem.sentence();
+    const memberIdRanges = faker.helpers.weightedArrayElement(MEMBER_ID_RANGE);
+
+    article.memberId = faker.number.int({
+        min: memberIdRanges.min,
+        max: memberIdRanges.max,
+    });
+
+    article.title = faker.lorem.sentence({ min: 5, max: 10 }).slice(0, 20);
     article.content = faker.lorem.paragraph();
     article.startTime = faker.date.recent({ days: 365 });
     article.endTime = faker.date.soon({ days: 1, refDate: article.startTime });
     article.articleImage = faker.image.url();
-    article.memberId = faker.number.int({ min: 1, max: 100 });
     article.categoryId = faker.number.int({ min: 1, max: 16 });
-    article.regionId = faker.number.int({ min: 1, max: 2 });
+    article.regionId = faker.number.int({ min: 1, max: 1 });
     article.districtId = faker.number.int({ min: 1, max: 129 });
     article.createdAt = startDate;
     article.updatedAt = startDate;

--- a/src/database/factories/articlelike.factory.ts
+++ b/src/database/factories/articlelike.factory.ts
@@ -2,11 +2,34 @@ import { setSeederFactory } from "typeorm-extension";
 
 import { ArticleLikeEntity } from "@APP/entities/article-like.entity";
 
+import { ARTICLE_ID_RANGE } from "../utils/article-id-range.const";
+import { MEMBER_ID_RANGE } from "../utils/member-id-range.const";
+
+// export default setSeederFactory(ArticleLikeEntity, async () => {
+//     const articleLike = new ArticleLikeEntity();
+
+//     articleLike.articleId = 10000;
+//     articleLike.memberId = 10000;
+
+//     return articleLike;
+// });
+
 export default setSeederFactory(ArticleLikeEntity, async (faker) => {
     const articleLike = new ArticleLikeEntity();
 
-    articleLike.articleId = faker.number.int({ min: 1, max: 50000 });
-    articleLike.memberId = faker.number.int({ min: 1, max: 100 });
+    const memberIdRanges = faker.helpers.weightedArrayElement(MEMBER_ID_RANGE);
+
+    const articleRange = faker.helpers.weightedArrayElement(ARTICLE_ID_RANGE);
+
+    articleLike.memberId = faker.number.int({
+        min: memberIdRanges.min,
+        max: memberIdRanges.max,
+    });
+
+    articleLike.articleId = faker.number.int({
+        min: articleRange.min,
+        max: articleRange.max,
+    });
 
     return articleLike;
 });

--- a/src/database/factories/black-list.factory.ts
+++ b/src/database/factories/black-list.factory.ts
@@ -2,20 +2,22 @@ import { setSeederFactory } from "typeorm-extension";
 
 import { BlackListEntity } from "@APP/entities/black-list.entity";
 
+import { MEMBER_ID_RANGE } from "../utils/member-id-range.const";
+
 export default setSeederFactory(BlackListEntity, async (faker) => {
     const blackListEntry = new BlackListEntity();
 
-    let initiatorId = faker.number.int({ min: 1, max: 100 });
-    let targetId = faker.number.int({ min: 1, max: 100 });
+    const memberIdRanges = faker.helpers.weightedArrayElement(MEMBER_ID_RANGE);
 
-    // 자기 자신을 블랙 하는것을 방지 하기 위해
-    while (initiatorId === targetId) {
-        initiatorId = faker.number.int({ min: 1, max: 100 });
-        targetId = faker.number.int({ min: 1, max: 100 });
-    }
+    blackListEntry.blackerId = faker.number.int({
+        min: memberIdRanges.min,
+        max: memberIdRanges.max,
+    });
 
-    blackListEntry.blackerId = initiatorId;
-    blackListEntry.blackedId = targetId;
+    blackListEntry.blackedId = faker.number.int({
+        min: memberIdRanges.min,
+        max: memberIdRanges.max,
+    });
 
     return blackListEntry;
 });

--- a/src/database/factories/member.factory.ts
+++ b/src/database/factories/member.factory.ts
@@ -1,15 +1,20 @@
-import * as bcrypt from "bcrypt";
 import { setSeederFactory } from "typeorm-extension";
 
 import { MemberEntity } from "../../entities/member.entity";
 
 export default setSeederFactory(MemberEntity, async (faker) => {
-    const hashedPassword = await bcrypt.hash("123456", 10);
+    // bcrypt 로 해싱하면 너무 느려서 미리 해싱
+    const hashedPassword =
+        "$2b$10$2AzriinQGFUi0HE2LNReqeWopVZKYMKlAM9t0TjGRztoCdpSsnXva";
+
+    const timestamp = Date.now();
+    const randomString = Math.random().toString(36).substring(2, 8);
+    const email = `user_${timestamp}_${randomString}@${faker.internet.domainName()}`;
 
     const member = new MemberEntity();
     member.name = faker.person.firstName();
     member.nickname = faker.person.lastName();
-    member.email = faker.internet.email();
+    member.email = email;
     member.password = hashedPassword;
     member.isEmailVerified = true;
     member.profileImage = Math.random() > 0.5 ? faker.image.avatar() : null;

--- a/src/database/factories/participation.factory.ts
+++ b/src/database/factories/participation.factory.ts
@@ -3,11 +3,26 @@ import { setSeederFactory } from "typeorm-extension";
 import { ParticipationStatus } from "@APP/common/enum/participation-status.enum";
 import { ParticipationEntity } from "@APP/entities/participation.entity";
 
+import { ARTICLE_ID_RANGE } from "../utils/article-id-range.const";
+import { MEMBER_ID_RANGE } from "../utils/member-id-range.const";
+
 export default setSeederFactory(ParticipationEntity, async (faker) => {
     const participation = new ParticipationEntity();
 
-    participation.articleId = faker.number.int({ min: 1, max: 50000 });
-    participation.memberId = faker.number.int({ min: 1, max: 100 });
+    const memberIdRanges = faker.helpers.weightedArrayElement(MEMBER_ID_RANGE);
+
+    const articleRange = faker.helpers.weightedArrayElement(ARTICLE_ID_RANGE);
+
+    participation.memberId = faker.number.int({
+        min: memberIdRanges.min,
+        max: memberIdRanges.max,
+    });
+
+    participation.articleId = faker.number.int({
+        min: articleRange.min,
+        max: articleRange.max,
+    });
+
     participation.status =
         Math.random() > 0.8
             ? ParticipationStatus.ACTIVE

--- a/src/database/factories/refresh-token.factory.ts
+++ b/src/database/factories/refresh-token.factory.ts
@@ -1,24 +1,13 @@
-import * as bcrypt from "bcrypt";
-import jwt from "jsonwebtoken";
 import { setSeederFactory } from "typeorm-extension";
 
-import { ENV_JWT_SECRET_KEY } from "@APP/common/constants/env-keys.const";
 import { RefreshTokenEntity } from "@APP/entities/refresh-token.entity";
 
-export default setSeederFactory(RefreshTokenEntity, async (faker) => {
-    const payload = {
-        email: faker.internet.email(),
-        sub: faker.number.int(),
-        type: "refresh",
-    };
-
-    const secret = process.env[ENV_JWT_SECRET_KEY] || "secret";
-    const expiresIn = "3600";
-
+export default setSeederFactory(RefreshTokenEntity, async () => {
     const refreshToken = new RefreshTokenEntity();
 
-    const token = jwt.sign(payload, secret, { expiresIn });
-    refreshToken.token = await bcrypt.hash(token, 10);
+    // bcrypt 해시가 너무 오래 걸려 미리 해싱
+    refreshToken.token =
+        "$2b$10$ndYzoPCCXt.24qzOusAB/OYMqaS1UKVqQsGvQh9t/MaqFqgg.g0fO";
 
     return refreshToken;
 });

--- a/src/database/seeds/article.seeder.ts
+++ b/src/database/seeds/article.seeder.ts
@@ -3,15 +3,77 @@ import { Seeder, SeederFactoryManager } from "typeorm-extension";
 
 import { ArticleEntity } from "@APP/entities/article.entity";
 
+// export default class ArticleSeeder implements Seeder {
+//     public async run(
+//         _dataSource: DataSource,
+//         factoryManager: SeederFactoryManager,
+//     ): Promise<void> {
+//         const articleFactory = factoryManager.get(ArticleEntity);
+
+//         const batchSize = 30_00;
+//         const totalArticles = 300_00;
+//         const iterations = totalArticles / batchSize;
+
+//         let totalCreated = 0;
+
+//         for (let i = 0; i < iterations; i++) {
+//             const articles = await articleFactory.saveMany(batchSize);
+//             totalCreated += articles.length;
+//             console.log(
+//                 `${i + 1}번째 배치 게시글 생성 완료: ${articles.length}`,
+//             );
+//         }
+
+//         console.log(`총 게시글 생성 완료: ${totalCreated}`);
+//     }
+// }
+
 export default class ArticleSeeder implements Seeder {
     public async run(
-        _dataSource: DataSource,
+        dataSource: DataSource,
         factoryManager: SeederFactoryManager,
     ): Promise<void> {
         const articleFactory = factoryManager.get(ArticleEntity);
+        const queryRunner = dataSource.createQueryRunner();
 
-        const articles = await articleFactory.saveMany(1);
+        const batchSize = 1000;
+        const totalArticles = 100000;
+        const iterations = Math.ceil(totalArticles / batchSize);
 
-        console.log(`게시글 생성 완료 : ${articles.length}`);
+        let totalCreated = 0;
+
+        try {
+            await queryRunner.connect();
+            await queryRunner.startTransaction();
+
+            for (let i = 0; i < iterations; i++) {
+                const articles = await Promise.all(
+                    Array.from({ length: batchSize }, () =>
+                        articleFactory.make(),
+                    ),
+                );
+
+                const result = await queryRunner.manager
+                    .createQueryBuilder()
+                    .insert()
+                    .into(ArticleEntity)
+                    .values(articles)
+                    .orIgnore()
+                    .execute();
+
+                totalCreated += result.identifiers.length;
+                console.log(
+                    `${i + 1}번째 배치 게시글 생성 완료: ${result.identifiers.length}`,
+                );
+            }
+
+            await queryRunner.commitTransaction();
+            console.log(`총 게시글 생성 완료: ${totalCreated}`);
+        } catch (error) {
+            await queryRunner.rollbackTransaction();
+            throw error;
+        } finally {
+            await queryRunner.release();
+        }
     }
 }

--- a/src/database/seeds/articlelike.seeder.ts
+++ b/src/database/seeds/articlelike.seeder.ts
@@ -3,15 +3,65 @@ import { Seeder, SeederFactoryManager } from "typeorm-extension";
 
 import { ArticleLikeEntity } from "@APP/entities/article-like.entity";
 
+// export default class ArticleLikeSeeder implements Seeder {
+//     public async run(
+//         _dataSource: DataSource,
+//         factoryManager: SeederFactoryManager,
+//     ): Promise<void> {
+//         const articleLikeFactory = factoryManager.get(ArticleLikeEntity);
+
+//         await articleLikeFactory.saveMany(180000);
+
+//         console.log(`게시글 좋아요 생성 완료`);
+//     }
+// }
+
 export default class ArticleLikeSeeder implements Seeder {
     public async run(
-        _dataSource: DataSource,
+        dataSource: DataSource,
         factoryManager: SeederFactoryManager,
     ): Promise<void> {
         const articleLikeFactory = factoryManager.get(ArticleLikeEntity);
+        const queryRunner = dataSource.createQueryRunner();
 
-        await articleLikeFactory.saveMany(180000);
+        const batchSize = 1000;
+        const totalLikes = 100000;
+        const iterations = Math.ceil(totalLikes / batchSize);
 
-        console.log(`게시글 좋아요 생성 완료`);
+        let totalCreated = 0;
+
+        try {
+            await queryRunner.connect();
+            await queryRunner.startTransaction();
+
+            for (let i = 0; i < iterations; i++) {
+                const articleLikes = await Promise.all(
+                    Array.from({ length: batchSize }, () =>
+                        articleLikeFactory.make(),
+                    ),
+                );
+
+                const result = await queryRunner.manager
+                    .createQueryBuilder()
+                    .insert()
+                    .into(ArticleLikeEntity)
+                    .values(articleLikes)
+                    .orIgnore()
+                    .execute();
+
+                totalCreated += result.identifiers.length;
+                console.log(
+                    `${i + 1}번째 배치 게시글 좋아요 생성 완료: ${result.identifiers.length}`,
+                );
+            }
+
+            await queryRunner.commitTransaction();
+            console.log(`총 게시글 좋아요 생성 완료: ${totalCreated}`);
+        } catch (error) {
+            await queryRunner.rollbackTransaction();
+            throw error;
+        } finally {
+            await queryRunner.release();
+        }
     }
 }

--- a/src/database/seeds/black-list.seeder.ts
+++ b/src/database/seeds/black-list.seeder.ts
@@ -3,15 +3,65 @@ import { Seeder, SeederFactoryManager } from "typeorm-extension";
 
 import { BlackListEntity } from "@APP/entities/black-list.entity";
 
+// export default class BlackListSeeder implements Seeder {
+//     public async run(
+//         _dataSource: DataSource,
+//         factoryManager: SeederFactoryManager,
+//     ): Promise<void> {
+//         const blackListFactory = factoryManager.get(BlackListEntity);
+
+//         await blackListFactory.saveMany(10000);
+
+//         console.log(`블랙 리스트 생성 완료`);
+//     }
+// }
+
 export default class BlackListSeeder implements Seeder {
     public async run(
-        _dataSource: DataSource,
+        dataSource: DataSource,
         factoryManager: SeederFactoryManager,
     ): Promise<void> {
         const blackListFactory = factoryManager.get(BlackListEntity);
+        const queryRunner = dataSource.createQueryRunner();
 
-        await blackListFactory.saveMany(10000);
+        const batchSize = 100;
+        const totalBlackLists = 8000;
+        const iterations = Math.ceil(totalBlackLists / batchSize);
 
-        console.log(`블랙 리스트 생성 완료`);
+        let totalCreated = 0;
+
+        try {
+            await queryRunner.connect();
+            await queryRunner.startTransaction();
+
+            for (let i = 0; i < iterations; i++) {
+                const blackLists = await Promise.all(
+                    Array.from({ length: batchSize }, () =>
+                        blackListFactory.make(),
+                    ),
+                );
+
+                const result = await queryRunner.manager
+                    .createQueryBuilder()
+                    .insert()
+                    .into(BlackListEntity)
+                    .values(blackLists)
+                    .orIgnore() // blackerId와 blackedId의 unique constraint 때문에 추가
+                    .execute();
+
+                totalCreated += result.identifiers.length;
+                console.log(
+                    `${i + 1}번째 배치 블랙리스트 생성 완료: ${result.identifiers.length}`,
+                );
+            }
+
+            await queryRunner.commitTransaction();
+            console.log(`총 블랙리스트 생성 완료: ${totalCreated}`);
+        } catch (error) {
+            await queryRunner.rollbackTransaction();
+            throw error;
+        } finally {
+            await queryRunner.release();
+        }
     }
 }

--- a/src/database/seeds/member.seeder.ts
+++ b/src/database/seeds/member.seeder.ts
@@ -3,25 +3,73 @@ import { Seeder, SeederFactoryManager } from "typeorm-extension";
 
 import { MemberEntity } from "@APP/entities/member.entity";
 
-//import { RefreshTokenEntity } from "@APP/entities/refresh-token.entity";
+// export default class MemberSeeder implements Seeder {
+//     public async run(
+//         _dataSource: DataSource,
+//         factoryManager: SeederFactoryManager,
+//     ): Promise<void> {
+//         const memberFactory = factoryManager.get(MemberEntity);
+//         const batchSize = 30_00;
+//         const totalMembers = 300_00;
+//         const iterations = totalMembers / batchSize;
+
+//         let totalCreated = 0;
+
+//         for (let i = 0; i < iterations; i++) {
+//             const members = await memberFactory.saveMany(batchSize);
+//             totalCreated += members.length;
+//             console.log(`${i + 1}번째 배치 멤버 생성 완료: ${members.length}`);
+//         }
+
+//         console.log(`총 멤버 생성 완료: ${totalCreated}`);
+//     }
+// }
 
 export default class MemberSeeder implements Seeder {
     public async run(
-        _dataSource: DataSource,
+        dataSource: DataSource,
         factoryManager: SeederFactoryManager,
     ): Promise<void> {
         const memberFactory = factoryManager.get(MemberEntity);
+        const queryRunner = dataSource.createQueryRunner();
 
-        // const refreshTokenFactory = factoryManager.get(RefreshTokenEntity);
+        const batchSize = 1000;
+        const totalMembers = 100000;
+        const iterations = Math.ceil(totalMembers / batchSize);
 
-        // const refreshToken = await refreshTokenFactory.save();
+        let totalCreated = 0;
 
-        // const member = await memberFactory.save({
-        //     refreshToken: refreshToken,
-        // });
+        try {
+            await queryRunner.connect();
+            await queryRunner.startTransaction();
 
-        const members = await memberFactory.saveMany(1);
+            for (let i = 0; i < iterations; i++) {
+                const members = await Promise.all(
+                    Array.from({ length: batchSize }, () =>
+                        memberFactory.make(),
+                    ),
+                );
 
-        console.log(`멤버 생성 완료 : ${members.length}`);
+                const result = await queryRunner.manager
+                    .createQueryBuilder()
+                    .insert()
+                    .into(MemberEntity)
+                    .values(members)
+                    .execute();
+
+                totalCreated += result.identifiers.length;
+                console.log(
+                    `${i + 1}번째 배치 멤버 생성 완료: ${result.identifiers.length}`,
+                );
+            }
+
+            await queryRunner.commitTransaction();
+            console.log(`총 멤버 생성 완료: ${totalCreated}`);
+        } catch (error) {
+            await queryRunner.rollbackTransaction();
+            throw error;
+        } finally {
+            await queryRunner.release();
+        }
     }
 }

--- a/src/database/seeds/participation.seeder.ts
+++ b/src/database/seeds/participation.seeder.ts
@@ -3,15 +3,65 @@ import { Seeder, SeederFactoryManager } from "typeorm-extension";
 
 import { ParticipationEntity } from "@APP/entities/participation.entity";
 
+// export default class ParticipationSeeder implements Seeder {
+//     public async run(
+//         _dataSource: DataSource,
+//         factoryManager: SeederFactoryManager,
+//     ): Promise<void> {
+//         const participationFactory = factoryManager.get(ParticipationEntity);
+
+//         const participations = await participationFactory.saveMany(180000);
+
+//         console.log(`참여 생성 완료 : ${participations.length}`);
+//     }
+// }
+
 export default class ParticipationSeeder implements Seeder {
     public async run(
-        _dataSource: DataSource,
+        dataSource: DataSource,
         factoryManager: SeederFactoryManager,
     ): Promise<void> {
         const participationFactory = factoryManager.get(ParticipationEntity);
+        const queryRunner = dataSource.createQueryRunner();
 
-        const participations = await participationFactory.saveMany(180000);
+        const batchSize = 1000;
+        const totalParticipations = 200000;
+        const iterations = Math.ceil(totalParticipations / batchSize);
 
-        console.log(`참여 생성 완료 : ${participations.length}`);
+        let totalCreated = 0;
+
+        try {
+            await queryRunner.connect();
+            await queryRunner.startTransaction();
+
+            for (let i = 0; i < iterations; i++) {
+                const participations = await Promise.all(
+                    Array.from({ length: batchSize }, () =>
+                        participationFactory.make(),
+                    ),
+                );
+
+                const result = await queryRunner.manager
+                    .createQueryBuilder()
+                    .insert()
+                    .into(ParticipationEntity)
+                    .values(participations)
+                    .orIgnore() // articleId와 memberId의 unique constraint 때문에 추가
+                    .execute();
+
+                totalCreated += result.identifiers.length;
+                console.log(
+                    `${i + 1}번째 배치 참여 생성 완료: ${result.identifiers.length}`,
+                );
+            }
+
+            await queryRunner.commitTransaction();
+            console.log(`총 참여 생성 완료: ${totalCreated}`);
+        } catch (error) {
+            await queryRunner.rollbackTransaction();
+            throw error;
+        } finally {
+            await queryRunner.release();
+        }
     }
 }

--- a/src/database/seeds/refresh-token.seeder.ts
+++ b/src/database/seeds/refresh-token.seeder.ts
@@ -3,15 +3,64 @@ import { Seeder, SeederFactoryManager } from "typeorm-extension";
 
 import { RefreshTokenEntity } from "@APP/entities/refresh-token.entity";
 
+// export default class RefreshTokenSeeder implements Seeder {
+//     public async run(
+//         _dataSource: DataSource,
+//         factoryManager: SeederFactoryManager,
+//     ): Promise<void> {
+//         const refreshTokenFactory = factoryManager.get(RefreshTokenEntity);
+
+//         await refreshTokenFactory.save();
+
+//         console.log(`리프레시토큰 생성 완료`);
+//     }
+// }
+
 export default class RefreshTokenSeeder implements Seeder {
     public async run(
-        _dataSource: DataSource,
+        dataSource: DataSource,
         factoryManager: SeederFactoryManager,
     ): Promise<void> {
         const refreshTokenFactory = factoryManager.get(RefreshTokenEntity);
+        const queryRunner = dataSource.createQueryRunner();
 
-        await refreshTokenFactory.save();
+        const batchSize = 1000;
+        const totalTokens = 100000;
+        const iterations = Math.ceil(totalTokens / batchSize);
 
-        console.log(`리프레시토큰 생성 완료`);
+        let totalCreated = 0;
+
+        try {
+            await queryRunner.connect();
+            await queryRunner.startTransaction();
+
+            for (let i = 0; i < iterations; i++) {
+                const refreshTokens = await Promise.all(
+                    Array.from({ length: batchSize }, () =>
+                        refreshTokenFactory.make(),
+                    ),
+                );
+
+                const result = await queryRunner.manager
+                    .createQueryBuilder()
+                    .insert()
+                    .into(RefreshTokenEntity)
+                    .values(refreshTokens)
+                    .execute();
+
+                totalCreated += result.identifiers.length;
+                console.log(
+                    `${i + 1}번째 배치 리프레시토큰 생성 완료: ${result.identifiers.length}`,
+                );
+            }
+
+            await queryRunner.commitTransaction();
+            console.log(`총 리프레시토큰 생성 완료: ${totalCreated}`);
+        } catch (error) {
+            await queryRunner.rollbackTransaction();
+            throw error;
+        } finally {
+            await queryRunner.release();
+        }
     }
 }

--- a/src/database/seeds/verification-code.seeder.ts
+++ b/src/database/seeds/verification-code.seeder.ts
@@ -3,17 +3,68 @@ import { Seeder, SeederFactoryManager } from "typeorm-extension";
 
 import { VerificationCodeEntity } from "@APP/entities/verification-code.entity";
 
+// export default class VerificationCodeSeeder implements Seeder {
+//     public async run(
+//         _dataSource: DataSource,
+//         factoryManager: SeederFactoryManager,
+//     ): Promise<void> {
+//         const verificationCodeFactory = factoryManager.get(
+//             VerificationCodeEntity,
+//         );
+
+//         await verificationCodeFactory.save();
+
+//         console.log(`인증코드 생성 완료`);
+//     }
+// }
+
 export default class VerificationCodeSeeder implements Seeder {
     public async run(
-        _dataSource: DataSource,
+        dataSource: DataSource,
         factoryManager: SeederFactoryManager,
     ): Promise<void> {
         const verificationCodeFactory = factoryManager.get(
             VerificationCodeEntity,
         );
+        const queryRunner = dataSource.createQueryRunner();
 
-        await verificationCodeFactory.save();
+        const batchSize = 1000;
+        const totalCodes = 100000;
+        const iterations = Math.ceil(totalCodes / batchSize);
 
-        console.log(`인증코드 생성 완료`);
+        let totalCreated = 0;
+
+        try {
+            await queryRunner.connect();
+            await queryRunner.startTransaction();
+
+            for (let i = 0; i < iterations; i++) {
+                const verificationCodes = await Promise.all(
+                    Array.from({ length: batchSize }, () =>
+                        verificationCodeFactory.make(),
+                    ),
+                );
+
+                const result = await queryRunner.manager
+                    .createQueryBuilder()
+                    .insert()
+                    .into(VerificationCodeEntity)
+                    .values(verificationCodes)
+                    .execute();
+
+                totalCreated += result.identifiers.length;
+                console.log(
+                    `${i + 1}번째 배치 인증코드 생성 완료: ${result.identifiers.length}`,
+                );
+            }
+
+            await queryRunner.commitTransaction();
+            console.log(`총 인증코드 생성 완료: ${totalCreated}`);
+        } catch (error) {
+            await queryRunner.rollbackTransaction();
+            throw error;
+        } finally {
+            await queryRunner.release();
+        }
     }
 }

--- a/src/database/utils/article-id-range.const.ts
+++ b/src/database/utils/article-id-range.const.ts
@@ -1,0 +1,11 @@
+export const ARTICLE_ID_RANGE = [
+    { weight: 40, value: { min: 10001, max: 15000 } }, // 40% 확률
+    { weight: 15, value: { min: 15001, max: 17500 } }, // 15% 확률
+    { weight: 15, value: { min: 17501, max: 20000 } }, // 15% 확률
+    { weight: 10, value: { min: 20001, max: 25000 } }, // 10% 확률
+    { weight: 10, value: { min: 25001, max: 30000 } }, // 10% 확률
+    { weight: 1, value: { min: 1000, max: 10000 } }, // 1% 확률
+    { weight: 2, value: { min: 30001, max: 40000 } }, // 2% 확률
+    { weight: 3, value: { min: 40001, max: 50000 } }, // 3% 확률
+    { weight: 4, value: { min: 50001, max: 60000 } }, // 4% 확률
+];

--- a/src/database/utils/member-id-range.const.ts
+++ b/src/database/utils/member-id-range.const.ts
@@ -1,0 +1,11 @@
+export const MEMBER_ID_RANGE = [
+    { weight: 40, value: { min: 10001, max: 15000 } }, // 40% 확률
+    { weight: 15, value: { min: 15001, max: 17500 } }, // 15% 확률
+    { weight: 15, value: { min: 17501, max: 20000 } }, // 15% 확률
+    { weight: 10, value: { min: 20001, max: 25000 } }, // 10% 확률
+    { weight: 10, value: { min: 25001, max: 30000 } }, // 10% 확률
+    { weight: 1, value: { min: 1000, max: 10000 } }, // 1% 확률
+    { weight: 2, value: { min: 30001, max: 40000 } }, // 2% 확률
+    { weight: 3, value: { min: 40001, max: 50000 } }, // 3% 확률
+    { weight: 4, value: { min: 50001, max: 60000 } }, // 4% 확률
+];

--- a/src/entities/article-like.entity.ts
+++ b/src/entities/article-like.entity.ts
@@ -1,8 +1,9 @@
-import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from "typeorm";
+import { Entity, JoinColumn, ManyToOne, PrimaryColumn, Unique } from "typeorm";
 
 import { ArticleEntity } from "./article.entity";
 import { MemberEntity } from "./member.entity";
 
+@Unique(["articleId", "memberId"])
 @Entity("article_likes")
 export class ArticleLikeEntity {
     @PrimaryColumn({ type: "int" })

--- a/src/entities/black-list.entity.ts
+++ b/src/entities/black-list.entity.ts
@@ -4,8 +4,10 @@ import {
     Entity,
     PrimaryColumn,
     PrimaryGeneratedColumn,
+    Unique,
 } from "typeorm";
 
+@Unique(["blackerId", "blackedId"])
 @Entity("black_list")
 export class BlackListEntity {
     @PrimaryGeneratedColumn()

--- a/src/entities/district.entity.ts
+++ b/src/entities/district.entity.ts
@@ -5,11 +5,13 @@ import {
     ManyToOne,
     OneToMany,
     PrimaryGeneratedColumn,
+    Unique,
 } from "typeorm";
 
 import { ArticleEntity } from "./article.entity";
 import { RegionEntity } from "./region.entity";
 
+@Unique(["regionId", "name"])
 @Entity("district")
 export class DistrictEntity {
     @PrimaryGeneratedColumn({ type: "int" })

--- a/src/entities/participation.entity.ts
+++ b/src/entities/participation.entity.ts
@@ -6,6 +6,7 @@ import {
     JoinColumn,
     ManyToOne,
     PrimaryGeneratedColumn,
+    Unique,
 } from "typeorm";
 
 import { ParticipationStatus } from "@APP/common/enum/participation-status.enum";
@@ -13,6 +14,7 @@ import { ParticipationStatus } from "@APP/common/enum/participation-status.enum"
 import { ArticleEntity } from "./article.entity";
 import { MemberEntity } from "./member.entity";
 
+@Unique(["articleId", "memberId"])
 @Entity({ name: "participation" })
 export class ParticipationEntity {
     @PrimaryGeneratedColumn({ type: "int" })

--- a/src/services/participations.service.ts
+++ b/src/services/participations.service.ts
@@ -129,13 +129,11 @@ export class ParticipationsService {
             );
         }
 
-        const updatedParticipation = this.createParticipationEntity(
-            currentMemberId,
-            body,
-            ParticipationStatus.ACTIVE,
-        );
-
-        return this.participationsRepository.save(updatedParticipation);
+        // 기존 참여 정보가 있고 CANCELLED 상태인 경우, update를 사용
+        return this.participationsRepository.save({
+            ...participation,
+            status: ParticipationStatus.ACTIVE,
+        });
     }
 
     private createParticipationEntity(


### PR DESCRIPTION
* Resolves #66 

## ✨ **구현 기능 명세**
- `typeorm-extension`에서 제공 해주는 `saveMany` 대신 쿼리 빌더를 통해서 Insert 하여 개선 하였습니다.

## 🎁 **주목할 점**
- seeder를 사용하면서 2가지 문제점을 겪었습니다.
1. `typeorm-extension`의 `saveMany`가 내부적으로는 루프를 돌면서 저장을 하였습니다.
2. `typeorm`의 `save` 메서드는 내부적으로 QueryBuilder를 사용하여 select 쿼리를 실행한 후, 데이터가 존재하면 update, 존재하지 않으면 insert를 실행 하였습니다.

- 이를 개선 하기 위해서 쿼리 빌더를 통해서 insert하여 성능을 개선 하였습니다.

## 😭 **어려웠던 점**

- `typeorm-extension`에서 `saveMany` 함수를 사용하면 루프를 돌면서 하나씩 실행 하면서 `save` 메서드로 저장 하는 방식으로 데이터가 많으면 많을수록 매우 큰 성능 저하를 가져왔습니다.

## 🌄 **스크린샷**

**typeorm-extension saveMany**

![image](https://github.com/user-attachments/assets/bbd4f0b7-0f7d-4f20-84ff-97eaed289b76)

**typeorm**
![image](https://github.com/user-attachments/assets/1022ad3f-e1fb-49a2-b8e0-fd6f1399538c)


## Reference
- [typeorm-extension saveMany 코드 링크](https://github.com/tada5hi/typeorm-extension/blob/cf8e640d8a65a28e0d18ea16161f8663af4f2d82/src/seeder/factory/module.ts#L76)
- [typeorm save 구현체](https://github.com/typeorm/typeorm/blob/19a6954d8b80ef23f0c3fb759c470c6a946d41a2/src/entity-manager/EntityManager.ts#L404)
- [typeorm save에서 호출하는 excutor](https://github.com/typeorm/typeorm/blob/master/src/persistence/EntityPersistExecutor.ts)
- [typeorm excutor에서 호출하는 subject-excutor](https://github.com/typeorm/typeorm/blob/19a6954d8b80ef23f0c3fb759c470c6a946d41a2/src/persistence/SubjectExecutor.ts)